### PR TITLE
Print last buffer

### DIFF
--- a/daq/default.ini
+++ b/daq/default.ini
@@ -15,7 +15,7 @@
 ## sampling rate in Msamples/second
 sample_rate= 1100
 ## do we supply this externally
-ext_clock_mode= 1
+ext_clock_mode= 0
 ## what we tell the digi card
 ## software will do internal conversions
 ## based on sample_rate above
@@ -26,18 +26,20 @@ spc_ref_clock= 1250
 
 ## FFT size = 2**FFT_power.
 ## this also sets the output rate
-FFT_power= 15
+FFT_power= 27
 ## We allocate memory for this many FFT size array
 buf_mult= 2
 
 ## number of samples, 0 for forever
-nsamples= 0
+nsamples= 10
 
 ## (only used if wave_nbytes>0)
 ## use with care -- this is resource intensive
 wave_nbytes= 0
 wave_fname= ../data/wave.bin
 
+##Print last digitizer buffer to file before exiting program (1 for yes, 0 for no)
+print_last_buffer= 1
 
 ## number of cuts
 ## each cut is a separate averaging of spectra
@@ -78,6 +80,8 @@ save_every= 60
 ## output patter will save this YYMMDD_HHMM.data
 ps_output_pattern= ../data/%02d%02d%02d_%02d%02d.data
 rfi_output_pattern= ../data/%02d%02d%02d_%02d%02d.outliers
+last_buffer_output_pattern= ../data/%02d%02d%02d_%02d%02d.lastBuffer
+
 ## interactive output 
 
 # print mean and variance

--- a/daq/digicard.cpp
+++ b/daq/digicard.cpp
@@ -271,13 +271,14 @@ void  digiWorkLoop(DIGICARD *dc, GPUCARD *gc, SETTINGS *set, FREQGEN *fgen, LJAC
       }
   }   
   
-  //Write last digitizer bufer to a file 
-  if(set->print_last_buffer){
-  	writerWriteLastBuffer(w, bufstart,dc->lNotifySize);
-  }
   printf("\n\n\n\n\n\n\n\n\n");
   if (stopSignal) printf ("Ctrl-C detected. Stopping.\n");
   if (sample_count==set->nsamples) printf ("Reached required number of samples.\n");
+  //Write last digitizer bufer to a file 
+  if(set->print_last_buffer){
+  	printf("Printing last digitizer buffer to a file...\n");
+  	writerWriteLastBuffer(w, bufstart,dc->lNotifySize);
+  }
   printf ("Stoping digitizer FIFO...\n");
   // send the stop command
   dwError = set->simulate_digitizer ? ERR_OK :

--- a/daq/digicard.cpp
+++ b/daq/digicard.cpp
@@ -184,7 +184,7 @@ void  digiWorkLoop(DIGICARD *dc, GPUCARD *gc, SETTINGS *set, FREQGEN *fgen, LJAC
   
   uint32      dwError;
   int32       lStatus, lAvailUser, lPCPos, fill;
-
+  int8_t * bufstart;
   // start everything
   dwError = set->simulate_digitizer ? ERR_OK :
     spcm_dwSetParam_i32 (dc->hCard, SPC_M2CMD, M2CMD_CARD_START | 
@@ -239,7 +239,7 @@ void  digiWorkLoop(DIGICARD *dc, GPUCARD *gc, SETTINGS *set, FREQGEN *fgen, LJAC
 	       accum, lStatus, lPCPos,fill);
 
 
-	int8_t* bufstart=((int8_t*)dc->pnData+lPCPos);
+	bufstart=((int8_t*)dc->pnData+lPCPos);
 	if (set->dont_process) 
 	  tprintfn (" ** no GPU processing");
 	else{
@@ -269,8 +269,12 @@ void  digiWorkLoop(DIGICARD *dc, GPUCARD *gc, SETTINGS *set, FREQGEN *fgen, LJAC
 	// return terminal cursor
 	treturn();
       }
+  }   
+  
+  //Write last digitizer bufer to a file 
+  if(set->print_last_buffer){
+  	writerWriteLastBuffer(w, bufstart,dc->lNotifySize);
   }
-    
   printf("\n\n\n\n\n\n\n\n\n");
   if (stopSignal) printf ("Ctrl-C detected. Stopping.\n");
   if (sample_count==set->nsamples) printf ("Reached required number of samples.\n");

--- a/daq/lastBuffer.ini
+++ b/daq/lastBuffer.ini
@@ -1,0 +1,110 @@
+##
+## CONFIGURATION FILE for BMXDAQ
+##
+
+## Rules for preserving health:
+##
+## Never eat yellow snow; don’t insert cutlery into power sockets; order
+## not the Monday night fish special and when setting bmxdaq options:
+##
+## option= value
+##       ^^ no space before equal sign, one space after
+##
+##
+
+## sampling rate in Msamples/second
+sample_rate= 1100
+## do we supply this externally
+ext_clock_mode= 1
+## what we tell the digi card
+## software will do internal conversions
+## based on sample_rate above
+## Don't change things below, unless you
+## know what are you doing.
+spc_sample_rate= 1250
+spc_ref_clock= 1250
+
+## FFT size = 2**FFT_power.
+## this also sets the output rate
+FFT_power= 27
+## We allocate memory for this many FFT size array
+buf_mult= 2
+
+## number of samples, 0 for forever
+nsamples= 1
+
+## (only used if wave_nbytes>0)
+## use with care -- this is resource intensive
+wave_nbytes= 0
+wave_fname= ../data/wave.bin
+
+##Print last digitizer buffer to file before exiting program (1 for yes, 0 for no)
+print_last_buffer= 1
+
+## number of cuts
+## each cut is a separate averaging of spectra
+## They can be overlapping, etc.
+n_cuts= 2
+## min and max frequency in Mhz, -1 sets max to Nyquist
+## Since 16384=2^14, we get 2^{27-14-1}=4096 channels.
+## (minus 1 because number of freq is # samples/2)
+nu_min0= 0.
+nu_max0= -1 
+fft_avg0= 16384;
+## Second cut catches tone around 1GHz
+nu_min1= 1399.9950
+nu_max1= 1400.0050
+fft_avg1= 1;
+
+## CUDA settings, don't touch unless you know
+## what you are doung
+cuda_streams= 2
+cuda_threads= 1024
+## Channel mask 1 = CH1, 2 = CH1, 3 = CH1+CH2 
+## (note that single channel taking hasn't really been tested)
+channel_mask= 3
+
+## ADC range in mV
+## possible values: 200,500,1000,2500
+ADC_range= 200
+
+## If one, don't acutally run the digitizer
+simulate_digitizer= 0
+## If one, don't run the GPU
+dont_process= 0
+
+## We open a new file every this many minutes
+## (execept the first one, for 60 we open so that 
+## mins==0)
+save_every= 60
+## output patter will save this YYMMDD_HHMM.data
+ps_output_pattern= ../data/%02d%02d%02d_%02d%02d.data
+rfi_output_pattern= ../data/%02d%02d%02d_%02d%02d.outliers
+last_buffer_output_pattern= ../data/last_buffer/%02d%02d%02d_%02d%02d.lastBuffer
+
+## interactive output 
+
+# print mean and variance
+print_meanvar= 1
+# print max power freq for each channel
+print_maxp= 1
+
+## tone frequency generation
+## if >0 it will try
+## to drive the tone generator
+fg_nfreq= 0
+## port baud rate for talking to FG
+fg_port= ttyS0
+fg_baudrate= 115200
+## switch every this many packets (determined by FFTSIZE and sampling
+## rate)
+fg_switchevery= 10
+## frequencies 0..fg_nfreq-1
+fg_freq0= 1200
+fg_freq1= 1400
+fg_freq2= 1500
+## amplitudes in Vpp
+fg_ampl0= 0.2
+fg_ampl1= 0.2
+fg_ampl2= 0.2
+

--- a/daq/settings.cpp
+++ b/daq/settings.cpp
@@ -36,6 +36,7 @@ void init_settings(SETTINGS *s, char* fname) {
     s->print_maxp=0;
     sprintf(s->ps_output_pattern,"%%02d%%02d%%02d_%%02d%%02d.data");
     sprintf(s->rfi_output_pattern,"%%02d%%02d%%02d_%%02d%%02d.outliers");
+    sprintf(s->last_buffer_output_pattern, "%%02d%%02d%%02d_%%02d%%02d.lastBuffer");
     s->fg_nfreq=0;
     s->fg_baudrate=9600;
     s->fg_switchevery=10;
@@ -52,6 +53,7 @@ void init_settings(SETTINGS *s, char* fname) {
     s->nsamples=0;
     s->wave_nbytes=0;
     sprintf(s->wave_fname,"wave.bin");
+    s->print_last_buffer = 0;
      
     if (fname) {
          FILE *fi;
@@ -109,6 +111,8 @@ void init_settings(SETTINGS *s, char* fname) {
 	     strcpy(s->ps_output_pattern,s2);
 	   else if(!strcmp(s1,"rfi_output_pattern="))
 	     strcpy(s->rfi_output_pattern,s2);
+           else if(!strcmp(s1,"last_buffer_output_pattern="))
+             strcpy(s->last_buffer_output_pattern,s2);
 	   else if(!strcmp(s1,"print_meanvar="))
 	     s->print_meanvar=atoi(s2);
 	   else if(!strcmp(s1,"print_maxp="))
@@ -127,8 +131,10 @@ void init_settings(SETTINGS *s, char* fname) {
 	     s->lj_Non=atoi(s2);
 	   else if(!strcmp(s1,"wave_fname="))
 	     strcpy(s->wave_fname,s2);
-	   else if(!strcmp(s1,"wave_nbytes="))
-	     s->wave_nbytes=atoi(s2);
+	   else if(!strcmp(s1,"print_last_buffer="))
+	     s->print_last_buffer=atoi(s2);
+           else if(!strcmp(s1,"wave_nbytes="))
+             s->wave_nbytes=atoi(s2);
 	   else if(!strcmp(s1,"log_chunk_size="))
 	     s->log_chunk_size=atoi(s2);
 	   else if(!strcmp(s1,"n_sigma_null="))

--- a/daq/settings.h
+++ b/daq/settings.h
@@ -30,6 +30,8 @@ struct SETTINGS {
   long int wave_nbytes;
   char wave_fname[MAXCHAR];
   
+  //print last digitizer  buffer to file before exiting program
+  int print_last_buffer;
 
   // size of FFT transform
   uint32_t fft_size; // must be power of 2
@@ -45,6 +47,7 @@ struct SETTINGS {
   // output options
   char ps_output_pattern[MAXCHAR];
   char rfi_output_pattern[MAXCHAR];
+  char last_buffer_output_pattern[MAXCHAR];
   int save_every;
   
   // printout options

--- a/daq/writer.cpp
+++ b/daq/writer.cpp
@@ -55,6 +55,7 @@ void writerInit(WRITER *writer, SETTINGS *s) {
   printf ("==========================\n");
   strcpy(writer->fnamePS,s->ps_output_pattern);
   strcpy(writer->fnameRFI,s->rfi_output_pattern);
+  strcpy(writer->fnameLastBuffer, s->last_buffer_output_pattern);
   writer->save_every=s->save_every;
   writer->headerPS.nChannels=1+(s->channel_mask==3);
   writer->headerPS.sample_rate=s->sample_rate;
@@ -109,6 +110,22 @@ void writerWriteRFI(WRITER * writer, int8_t * outlier, int chunk, int channel, f
   fwrite(&nSigma, sizeof(float), 1, writer->fRFI);
   fwrite (outlier, sizeof(int8_t), writer->lenRFI, writer->fRFI);
   fflush(writer->fRFI);
+}
+
+void writerWriteLastBuffer(WRITER * writer, int8_t * bufstart, int size){
+  time_t rawtime;
+  time (&rawtime);
+  struct tm *ti = localtime ( &rawtime );
+  sprintf(writer->afnameLastBuffer, writer->fnameLastBuffer, ti->tm_year - 100 , ti->tm_mon + 1,
+            ti->tm_mday, ti->tm_hour, ti->tm_min);
+  printf("NEW FILE: %s\n", writer->afnameLastBuffer);
+  FILE * fw = fopen(writer->afnameLastBuffer, "wb");
+  if(fw == NULL)
+	printf("CANNOT OPEN FILE: %s\n", writer->afnameLastBuffer);
+  else {
+  	fwrite(bufstart, sizeof(int8_t), size, fw);
+  	fclose(fw);
+  }
 }
 
 void writerCleanUp(WRITER *writer) {

--- a/daq/writer.h
+++ b/daq/writer.h
@@ -34,8 +34,8 @@ struct RFIHEADER {
 };
 
 struct WRITER {
-  char fnamePS[MAXFNLEN], fnameRFI[MAXFNLEN];  //file names, from settings
-  char afnamePS[MAXFNLEN], afnameRFI[MAXFNLEN];  //current file names
+  char fnamePS[MAXFNLEN], fnameRFI[MAXFNLEN], fnameLastBuffer[MAXFNLEN];  //file names, from settings
+  char afnamePS[MAXFNLEN], afnameRFI[MAXFNLEN],  afnameLastBuffer[MAXFNLEN];  //current file names
   char tafnamePS[MAXFNLEN], tafnameRFI[MAXFNLEN];  //temporary current file names 
                                                    //(with ".new")
   uint32_t lenPS; // full length of PS info
@@ -55,6 +55,7 @@ struct WRITER {
 void writerInit(WRITER *writer, SETTINGS *set);
 void writerWritePS (WRITER *writer, float* ps, int * numOutliersNulled);
 void writerWriteRFI(WRITER *writer, int8_t * outlier, int chunk, int channel, float nSigma);
+void writerWriteLastBuffer(WRITER *writer, int8_t * bufstart, int size);
 void writerCleanUp(WRITER *writer);
 void closeAndRename(WRITER *writer);
 

--- a/py/plotLastBuffer.py
+++ b/py/plotLastBuffer.py
@@ -4,6 +4,7 @@ import matplotlib.pyplot as plt
 import sys, glob, os, time
 from optparse import OptionParser
 
+## This assumes 2 channels.
 
 parser = OptionParser()
 parser.add_option("--points", dest="points", default = 1000, 

--- a/py/plotLastBuffer.py
+++ b/py/plotLastBuffer.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+import numpy as np
+import matplotlib.pyplot as plt
+import sys, glob, os, time
+from optparse import OptionParser
+
+
+parser = OptionParser()
+parser.add_option("--points", dest="points", default = 1000, 
+            type = 'int', help = "number of points to plot")
+parser.add_option("--f", dest="file", help= "name of file containing buffer")
+(o, args) = parser.parse_args()
+
+wfile = open(o.file)
+de=[('ch1','i1'),('ch2','i1')]
+da=np.fromfile(wfile,de)
+size = o.points  ##number of points to plot
+xx=np.arange(size)
+plt.figure(1)
+plt.subplot(211)
+plt.plot(xx,da['ch1'][0:size])
+plt.title("CH 1")
+plt.subplot(212)
+plt.plot(xx,da['ch2'][0:size])
+plt.title("CH 2")
+plt.show()
+
+
+
+
+


### PR DESCRIPTION
Added option to print last digitizer buffer to a file before closing the program.

Settings added: 

1) print_last_buffer - 1 for yes, 0 for no. Default is 0
2) last_buffer_output_pattern - pattern of file name default: "%%02d%%02d%%02d_%%02d%%02d.lastBuffer"

Script to plot the last buffer: 
bmxdaq/py/plotLastBuffer.py

Options: --points - number of points to plot
                --f - name of file containing buffer
e.g.
python ./plotLastBuffer.py --points 1000 --f ../data/44597111226_0850.lastBuffer